### PR TITLE
Support debugging  via `state` attribute

### DIFF
--- a/packages/mobx-binder-core/.eslintrc.js
+++ b/packages/mobx-binder-core/.eslintrc.js
@@ -2,4 +2,7 @@ module.exports =  {
     extends:  [
         '../mobx-binder-utils/.eslintrc.js',
     ],
+    parserOptions: {
+        project: 'tsconfig.json'
+    },
 };

--- a/packages/mobx-binder-core/src/conversion/Converter.ts
+++ b/packages/mobx-binder-core/src/conversion/Converter.ts
@@ -1,16 +1,18 @@
 /**
- * Interface to be fulfulled by any converter for use with `withConverter`
+ * Interface to be fulfilled by any converter for use with `withConverter`
  */
 export interface Converter<_ValidationResult, ViewType, ModelType> {
+    readonly label?: string
     convertToModel(value: ViewType): ModelType
     convertToPresentation(data: ModelType): ViewType
     isEqual?(first: ModelType, second: ModelType): boolean
 }
 
 /**
- * Interface to be fulfulled by any asynchronous converter for use with `withAsyncConverter`
+ * Interface to be fulfilled by any asynchronous converter for use with `withAsyncConverter`
  */
 export interface AsyncConverter<_ValidationResult, ViewType, ModelType> {
+    readonly label?: string
     convertToModel(value: ViewType): Promise<ModelType>
     convertToPresentation(data: ModelType): ViewType
     isEqual?(first: ModelType, second: ModelType): boolean

--- a/packages/mobx-binder-core/src/conversion/EmptyStringConverter.ts
+++ b/packages/mobx-binder-core/src/conversion/EmptyStringConverter.ts
@@ -1,7 +1,12 @@
 import { Converter } from './Converter'
+import { createLabel } from '../validation/Labels'
 
 export class EmptyStringConverter<X> implements Converter<any, string, string | X> {
-    constructor(private targetValue: X) {}
+    readonly label: string
+
+    constructor(private targetValue: X) {
+        this.label = createLabel('EmptyStringConverter', { targetValue })
+    }
 
     public convertToModel(value: string): string | X {
         return value === '' ? this.targetValue : value

--- a/packages/mobx-binder-core/src/conversion/ValidationError.ts
+++ b/packages/mobx-binder-core/src/conversion/ValidationError.ts
@@ -4,6 +4,6 @@ export class ValidationError<ValidationResult> extends Error {
     }
 }
 
-export function isValidationError<ValidationResult = any>(err: Error): err is ValidationError<ValidationResult> {
-    return err.hasOwnProperty('validationResult')
+export function isValidationError<ValidationResult = any>(err: unknown): err is ValidationError<ValidationResult> {
+    return (err as Error).hasOwnProperty('validationResult')
 }

--- a/packages/mobx-binder-core/src/index.ts
+++ b/packages/mobx-binder-core/src/index.ts
@@ -13,6 +13,7 @@ export { TrimConverter } from './conversion/TrimConverter'
 
 export * from './validation/Validity'
 export * from './validation/Validator'
+export { createLabel, withLabel, isLabeled } from './validation/Labels'
 
 export { ValidationError } from './conversion/ValidationError'
 export { isPromise } from './utils/isPromise'

--- a/packages/mobx-binder-core/src/model/binder/Binder.ts
+++ b/packages/mobx-binder-core/src/model/binder/Binder.ts
@@ -34,6 +34,9 @@ export interface Binding<FieldType, ValidationResult> {
      */
     readonly validity: Validity<ValidationResult>
 
+    /**
+     * The state of the field and all modifications for debugging purposes.
+     */
     readonly state: Array<ModifierState<ValidationResult>>
 
     /**

--- a/packages/mobx-binder-core/src/model/binder/Binder.ts
+++ b/packages/mobx-binder-core/src/model/binder/Binder.ts
@@ -594,7 +594,7 @@ export class Binder<ValidationResult> {
                         if (onSuccess) {
                             const newPromise = onSuccess(result as TargetType)
 
-                            if (newPromise && newPromise.then) {
+                            if (newPromise?.then) {
                                 return newPromise.then(() => result)
                             }
                         }

--- a/packages/mobx-binder-core/src/model/binder/Binder.ts
+++ b/packages/mobx-binder-core/src/model/binder/Binder.ts
@@ -15,6 +15,7 @@ import { isPromise } from '../../utils/isPromise'
 import { AsyncConvertingModifier } from './chain/AsyncConvertingModifier'
 import { Validity } from '../../validation/Validity'
 import { wrapRequiredValidator } from '../../validation/WrappedValidator'
+import { ModifierState } from './chain/ModifierState'
 
 /**
  * API for single field binding
@@ -32,6 +33,8 @@ export interface Binding<FieldType, ValidationResult> {
      * The validation status of the current binding.
      */
     readonly validity: Validity<ValidationResult>
+
+    readonly state: Array<ModifierState<ValidationResult>>
 
     /**
      * Load the field value from the source object, treating it as "unchanged" value.
@@ -150,6 +153,10 @@ class StandardBinding<FieldType, ValidationResult> implements Binding<FieldType,
             return this.customErrorMessage
         }
         return this.validity.status === 'validated' && !this.context.valid(this.validity.result) ? this.context.translate(this.validity.result) : undefined
+    }
+
+    public get state() {
+        return this.chain.bindingState
     }
 
     public setUnchanged() {

--- a/packages/mobx-binder-core/src/model/binder/Binder.ts
+++ b/packages/mobx-binder-core/src/model/binder/Binder.ts
@@ -35,7 +35,7 @@ export interface Binding<FieldType, ValidationResult> {
     readonly validity: Validity<ValidationResult>
 
     /**
-     * The state of the field and all modifications for debugging purposes.
+     * The state of the field and all modifications that happen in the validation/conversion chain for debugging purposes.
      */
     readonly state: Array<ModifierState<ValidationResult>>
 

--- a/packages/mobx-binder-core/src/model/binder/BinderSpec.ts
+++ b/packages/mobx-binder-core/src/model/binder/BinderSpec.ts
@@ -1483,6 +1483,7 @@ describe('Binder', () => {
                     more: undefined,
                 },
                 {
+                    name: undefined,
                     type: 'validation',
                     data: {
                         pending: true,

--- a/packages/mobx-binder-core/src/model/binder/BinderSpec.ts
+++ b/packages/mobx-binder-core/src/model/binder/BinderSpec.ts
@@ -1404,4 +1404,89 @@ describe('Binder', () => {
             })
         })
     })
+
+    describe('debugging', () => {
+        it('should provide the current state of a binding chain as a list', () => {
+            const binder = new SimpleBinder().forField(myField).bind()
+
+            expect(binder.binding(myField).state).to.deep.equal([
+                {
+                    type: 'field<string>',
+                    data: {
+                        pending: false,
+                        value: '',
+                    },
+                    required: false,
+                    validity: {
+                        result: undefined,
+                        status: 'validated',
+                    },
+                },
+            ])
+        })
+
+        it('should provide one entry for each chained modification', () => {
+            const binder = new SimpleBinder().forStringField(myField).bind()
+
+            expect(binder.binding(myField).state).to.deep.equal([
+                {
+                    type: 'field<string>',
+                    data: {
+                        pending: false,
+                        value: '',
+                    },
+                    required: false,
+                    validity: {
+                        result: undefined,
+                        status: 'validated',
+                    },
+                },
+                {
+                    type: 'conversion:EmptyStringConverter',
+                    data: {
+                        pending: false,
+                        value: undefined,
+                    },
+                    required: false,
+                    validity: {
+                        result: undefined,
+                        status: 'validated',
+                    },
+                },
+            ])
+        })
+
+        it('should provide one entry for each validator', () => {
+            const binder = new SimpleBinder()
+                .forField(myField)
+                .isRequired()
+                .bind()
+
+            expect(binder.binding(myField).state).to.deep.equal([
+                {
+                    type: 'field<string>',
+                    data: {
+                        pending: false,
+                        value: '',
+                    },
+                    required: false,
+                    validity: {
+                        result: undefined,
+                        status: 'validated',
+                    },
+                },
+                {
+                    type: 'validation',
+                    data: {
+                        pending: true,
+                    },
+                    required: true,
+                    validity: {
+                        result: 'Please enter a value',
+                        status: 'validated',
+                    },
+                },
+            ])
+        })
+    })
 })

--- a/packages/mobx-binder-core/src/model/binder/BinderSpec.ts
+++ b/packages/mobx-binder-core/src/model/binder/BinderSpec.ts
@@ -1483,7 +1483,7 @@ describe('Binder', () => {
                     more: undefined,
                 },
                 {
-                    name: undefined,
+                    name: 'required(value=true)',
                     type: 'validation',
                     data: {
                         pending: true,

--- a/packages/mobx-binder-core/src/model/binder/BinderSpec.ts
+++ b/packages/mobx-binder-core/src/model/binder/BinderSpec.ts
@@ -1411,6 +1411,7 @@ describe('Binder', () => {
 
             expect(binder.binding(myField).state).to.deep.equal([
                 {
+                    name: 'myField',
                     type: 'field<string>',
                     data: {
                         pending: false,
@@ -1421,6 +1422,7 @@ describe('Binder', () => {
                         result: undefined,
                         status: 'validated',
                     },
+                    more: undefined,
                 },
             ])
         })
@@ -1430,6 +1432,7 @@ describe('Binder', () => {
 
             expect(binder.binding(myField).state).to.deep.equal([
                 {
+                    name: 'myField',
                     type: 'field<string>',
                     data: {
                         pending: false,
@@ -1440,9 +1443,11 @@ describe('Binder', () => {
                         result: undefined,
                         status: 'validated',
                     },
+                    more: undefined,
                 },
                 {
-                    type: 'conversion:EmptyStringConverter',
+                    name: 'EmptyStringConverter',
+                    type: 'conversion',
                     data: {
                         pending: false,
                         value: undefined,
@@ -1464,6 +1469,7 @@ describe('Binder', () => {
 
             expect(binder.binding(myField).state).to.deep.equal([
                 {
+                    name: 'myField',
                     type: 'field<string>',
                     data: {
                         pending: false,
@@ -1474,6 +1480,7 @@ describe('Binder', () => {
                         result: undefined,
                         status: 'validated',
                     },
+                    more: undefined,
                 },
                 {
                     type: 'validation',

--- a/packages/mobx-binder-core/src/model/binder/chain/AbstractModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AbstractModifier.ts
@@ -16,7 +16,7 @@ export class AbstractModifier<ValidationResult, ViewType, ModelType> implements 
     }
 
     get type() {
-        return 'modification'
+        return 'unknown modification'
     }
 
     get data() {

--- a/packages/mobx-binder-core/src/model/binder/chain/AbstractModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AbstractModifier.ts
@@ -11,6 +11,10 @@ export class AbstractModifier<ValidationResult, ViewType, ModelType> implements 
         this.field = view.field
     }
 
+    get name(): string | undefined {
+        return undefined
+    }
+
     get type() {
         return 'modification'
     }
@@ -68,11 +72,12 @@ export class AbstractModifier<ValidationResult, ViewType, ModelType> implements 
     }
 
     public get bindingState(): Array<ModifierState<ValidationResult>> {
-        const { type, data, required, validity } = this
+        const { name, type, data, required, validity } = this
         return [
             ...this.view.bindingState,
             {
-                type: type,
+                name,
+                type,
                 data,
                 required,
                 validity,

--- a/packages/mobx-binder-core/src/model/binder/chain/AbstractModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AbstractModifier.ts
@@ -2,12 +2,17 @@ import { Data, Modifier, ValidValueValidationResult, ValueValidationResult } fro
 import { Context } from '../Context'
 import { isPromise } from '../../../utils/isPromise'
 import { FieldStore, Validity } from '../../..'
+import { ModifierState } from './ModifierState'
 
 export class AbstractModifier<ValidationResult, ViewType, ModelType> implements Modifier<ValidationResult, ViewType, ModelType> {
     public field: FieldStore<unknown>
 
     constructor(protected view: Modifier<ValidationResult, any, ViewType>, protected context: Context<ValidationResult>) {
         this.field = view.field
+    }
+
+    get type() {
+        return 'modification'
     }
 
     get data() {
@@ -60,5 +65,18 @@ export class AbstractModifier<ValidationResult, ViewType, ModelType> implements 
 
     public isEqual(first: ModelType, second: ModelType): boolean {
         return this.view.isEqual((first as any) as ViewType, (second as any) as ViewType)
+    }
+
+    public get bindingState(): Array<ModifierState<ValidationResult>> {
+        const { type, data, required, validity } = this
+        return [
+            ...this.view.bindingState,
+            {
+                type: type,
+                data,
+                required,
+                validity,
+            },
+        ]
     }
 }

--- a/packages/mobx-binder-core/src/model/binder/chain/AbstractModifierSpec.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AbstractModifierSpec.ts
@@ -24,12 +24,52 @@ describe('AbstractModifier', () => {
                 result: undefined,
             },
             field,
+            bindingState: [
+                {
+                    upstream: 'state',
+                },
+            ],
             toView: sandbox.stub().returnsArg(0),
             validateValue: sandbox.stub(),
             applyConversionsToField: sandbox.stub(),
             isEqual: sandbox.stub(),
         }
         modifier = new AbstractModifier<ErrorMessage, string, string>(upstream, context)
+    })
+
+    describe('name', () => {
+        it('should provide no name by default', () => {
+            expect(modifier.name).to.be.undefined
+        })
+    })
+
+    describe('type', () => {
+        it('should provide a type', () => {
+            expect(modifier.type).to.equal('unknown modification')
+        })
+    })
+
+    describe('bindingState', () => {
+        it('should provide the state of it\'s on and all "upstream" modifiers', () => {
+            expect(modifier.bindingState).to.deep.equal([
+                {
+                    upstream: 'state',
+                },
+                {
+                    name: undefined,
+                    type: 'unknown modification',
+                    data: {
+                        pending: false,
+                        value: 'myValue',
+                    },
+                    required: undefined,
+                    validity: {
+                        result: undefined,
+                        status: 'validated',
+                    },
+                },
+            ])
+        })
     })
 
     describe('data', () => {

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifier.ts
@@ -54,9 +54,13 @@ export class AsyncConvertingModifier<ValidationResult, ViewType, ModelType> exte
         })
     }
 
-    get type() {
+    get name() {
         const name = this.converter.constructor?.name
-        return name ? `async conversion:${name}` : 'async conversion'
+        return name && name !== 'Function' ? name : undefined
+    }
+
+    get type() {
+        return 'async conversion'
     }
 
     get data(): Data<ModelType> {

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifier.ts
@@ -54,6 +54,11 @@ export class AsyncConvertingModifier<ValidationResult, ViewType, ModelType> exte
         })
     }
 
+    get type() {
+        const name = this.converter.constructor?.name
+        return name ? `async conversion:${name}` : 'async conversion'
+    }
+
     get data(): Data<ModelType> {
         const upstreamData = this.view.data
         if (this.info.status === 'valid' && !upstreamData.pending && this.isAlreadyValidated(this.info, upstreamData.value)) {

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifier.ts
@@ -3,7 +3,7 @@ import { Data, Modifier, SyncValueValidationResult, ValidValueValidationResult }
 import { Context } from '../Context'
 import { AbstractModifier } from './AbstractModifier'
 import { AsyncConverter } from '../../../conversion/Converter'
-import { isValidationError } from '../../../conversion/ValidationError'
+import { isValidationError, ValidationError } from '../../../conversion/ValidationError'
 import { Validity } from '../../../validation/Validity'
 
 type AsyncConversionInfo<ViewType, ModelType, ValidationResult> =
@@ -154,7 +154,7 @@ export class AsyncConvertingModifier<ValidationResult, ViewType, ModelType> exte
                         this.info = {
                             status: 'invalid',
                             validatedValue: value,
-                            lastValidationResult: err.validationResult,
+                            lastValidationResult: (err as ValidationError<ValidationResult>).validationResult,
                         }
                     }
                 })

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifier.ts
@@ -55,7 +55,7 @@ export class AsyncConvertingModifier<ValidationResult, ViewType, ModelType> exte
     }
 
     get name() {
-        const name = this.converter.label || this.converter.constructor?.name
+        const name = this.converter.label || this.converter.constructor.name
         return name && name !== 'Function' ? name : undefined
     }
 

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifier.ts
@@ -55,7 +55,7 @@ export class AsyncConvertingModifier<ValidationResult, ViewType, ModelType> exte
     }
 
     get name() {
-        const name = this.converter.constructor?.name
+        const name = this.converter.label || this.converter.constructor?.name
         return name && name !== 'Function' ? name : undefined
     }
 

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifierSpec.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncConvertingModifierSpec.ts
@@ -44,6 +44,23 @@ describe('AsyncConvertingModifier', () => {
         modifier = new AsyncConvertingModifier<ErrorMessage, string | undefined, number | undefined>(upstream, context, createConverter(), { onBlur: false })
     })
 
+    describe('name', () => {
+        it('should provide a name of the converter', () => {
+            expect(modifier.name).to.equal('SimpleAsyncNumberConverter')
+        })
+
+        it('should support a label on the converter', () => {
+            ;(converter as any).label = 'Some converter'
+            expect(modifier.name).to.equal('Some converter')
+        })
+    })
+
+    describe('type', () => {
+        it('should provide a type', () => {
+            expect(modifier.type).to.equal('async conversion')
+        })
+    })
+
     describe('data', () => {
         it('should convert valid upstream data', async () => {
             await modifier.validateAsync(false)

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncValidatingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncValidatingModifier.ts
@@ -4,6 +4,7 @@ import { Context } from '../Context'
 import { AsyncValidator } from '../../../validation/Validator'
 import { AbstractModifier } from './AbstractModifier'
 import { Validity } from '../../../validation/Validity'
+import { isLabeled } from '../../../validation/Labels'
 
 type AsyncValidationInfo<ValueType, ValidationResult> =
     | KnownValidationInfo<ValueType, ValidationResult>
@@ -44,7 +45,7 @@ export class AsyncValidatingModifier<ValidationResult, ValueType> extends Abstra
     }
 
     get name() {
-        const name = this.validator.constructor?.name
+        const name = isLabeled(this.validator) ? this.validator.label : this.validator.constructor?.name
         return name && name !== 'Function' ? name : undefined
     }
 

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncValidatingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncValidatingModifier.ts
@@ -43,6 +43,11 @@ export class AsyncValidatingModifier<ValidationResult, ValueType> extends Abstra
         })
     }
 
+    get name() {
+        const name = this.validator.constructor?.name
+        return name && name !== 'Function' ? name : undefined
+    }
+
     get type() {
         return 'async validation'
     }

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncValidatingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncValidatingModifier.ts
@@ -45,8 +45,7 @@ export class AsyncValidatingModifier<ValidationResult, ValueType> extends Abstra
     }
 
     get name() {
-        const name = isLabeled(this.validator) ? this.validator.label : this.validator.constructor?.name
-        return name && name !== 'Function' ? name : undefined
+        return isLabeled(this.validator) ? this.validator.label : this.validator.name
     }
 
     get type() {

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncValidatingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncValidatingModifier.ts
@@ -43,6 +43,10 @@ export class AsyncValidatingModifier<ValidationResult, ValueType> extends Abstra
         })
     }
 
+    get type() {
+        return 'async validation'
+    }
+
     get data(): Data<ValueType> {
         const data = this.view.data
         if (

--- a/packages/mobx-binder-core/src/model/binder/chain/AsyncValidatingModifierSpec.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/AsyncValidatingModifierSpec.ts
@@ -1,4 +1,4 @@
-import { TextField } from '../../..'
+import { TextField, withLabel } from '../../..'
 import { ErrorMessage, SimpleContext } from '../SimpleBinder'
 import { expect } from 'chai'
 import { AsyncValidatingModifier } from './AsyncValidatingModifier'
@@ -43,6 +43,28 @@ describe('AsyncValidatingModifier', () => {
             return undefined
         })
         modifier = new AsyncValidatingModifier<ErrorMessage, string>(upstream, context, validatorMock, { onBlur: false })
+    })
+
+    describe('name', () => {
+        it('should provide a name of the converter', () => {
+            const myValidator = async (value: string) => (!!value ? 'required' : undefined)
+            modifier = new AsyncValidatingModifier<ErrorMessage, string>(upstream, context, myValidator, { onBlur: false })
+
+            expect(modifier.name).to.equal('myValidator')
+        })
+
+        it('should support a label on the converter', () => {
+            const myValidator = async (value: string) => (!!value ? 'required' : undefined)
+            validatorMock = withLabel('some validator', myValidator)
+            modifier = new AsyncValidatingModifier<ErrorMessage, string>(upstream, context, validatorMock, { onBlur: false })
+            expect(modifier.name).to.equal('some validator')
+        })
+    })
+
+    describe('type', () => {
+        it('should provide a type', () => {
+            expect(modifier.type).to.equal('async validation')
+        })
     })
 
     describe('data', () => {

--- a/packages/mobx-binder-core/src/model/binder/chain/ChangeEventHandler.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ChangeEventHandler.ts
@@ -16,12 +16,11 @@ export class ChangeEventHandler<ValidationResult, ValueType> extends AbstractMod
     }
 
     get name() {
-        const name = this.callback.constructor?.name
-        return name && name !== 'Function' ? name : undefined
+        return this.callback.name
     }
 
     get type() {
-        return 'change event'
+        return 'change event handler'
     }
 
     private handleChange = (data?: KnownData<ValueType>) => {

--- a/packages/mobx-binder-core/src/model/binder/chain/ChangeEventHandler.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ChangeEventHandler.ts
@@ -15,6 +15,10 @@ export class ChangeEventHandler<ValidationResult, ValueType> extends AbstractMod
         )
     }
 
+    get type() {
+        return 'change event'
+    }
+
     private handleChange = (data?: KnownData<ValueType>) => {
         if (data) {
             this.callback(data.value)

--- a/packages/mobx-binder-core/src/model/binder/chain/ChangeEventHandler.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ChangeEventHandler.ts
@@ -15,6 +15,11 @@ export class ChangeEventHandler<ValidationResult, ValueType> extends AbstractMod
         )
     }
 
+    get name() {
+        const name = this.callback.constructor?.name
+        return name && name !== 'Function' ? name : undefined
+    }
+
     get type() {
         return 'change event'
     }

--- a/packages/mobx-binder-core/src/model/binder/chain/ChangeEventHandlerSpec.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ChangeEventHandlerSpec.ts
@@ -8,6 +8,7 @@ import sinon = require('sinon')
 describe('ChangeEventHandler', () => {
     const sandbox = sinon.createSandbox()
     const context = new SimpleContext()
+    let modifier: ChangeEventHandler<ErrorMessage, string>
     let field: TextField
     let upstream: any
     let callbackMock: any
@@ -27,7 +28,24 @@ describe('ChangeEventHandler', () => {
             toView: sandbox.spy((value: any) => value),
         }
         callbackMock = sandbox.stub()
-        new ChangeEventHandler<ErrorMessage, string>(upstream, context, callbackMock)
+        modifier = new ChangeEventHandler<ErrorMessage, string>(upstream, context, callbackMock)
+    })
+
+    describe('name', () => {
+        it('should provide a name of the converter', () => {
+            const myHandler = () => {
+                /* do something */
+            }
+            modifier = new ChangeEventHandler<ErrorMessage, string>(upstream, context, myHandler)
+
+            expect(modifier.name).to.equal('myHandler')
+        })
+    })
+
+    describe('type', () => {
+        it('should provide a type', () => {
+            expect(modifier.type).to.equal('change event handler')
+        })
     })
 
     describe('handle change', () => {

--- a/packages/mobx-binder-core/src/model/binder/chain/ConvertingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ConvertingModifier.ts
@@ -18,9 +18,13 @@ export class ConvertingModifier<ValidationResult, ViewType, ModelType> extends A
         })
     }
 
-    get type() {
+    get name() {
         const name = this.converter.constructor?.name
-        return name ? `conversion:${name}` : 'conversion'
+        return name && name !== 'Function' ? name : undefined
+    }
+
+    get type() {
+        return 'conversion'
     }
 
     get data(): Data<ModelType> {

--- a/packages/mobx-binder-core/src/model/binder/chain/ConvertingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ConvertingModifier.ts
@@ -18,6 +18,11 @@ export class ConvertingModifier<ValidationResult, ViewType, ModelType> extends A
         })
     }
 
+    get type() {
+        const name = this.converter.constructor?.name
+        return name ? `conversion:${name}` : 'conversion'
+    }
+
     get data(): Data<ModelType> {
         const data = this.view.data
         if (data.pending) {

--- a/packages/mobx-binder-core/src/model/binder/chain/ConvertingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ConvertingModifier.ts
@@ -19,7 +19,7 @@ export class ConvertingModifier<ValidationResult, ViewType, ModelType> extends A
     }
 
     get name() {
-        const name = this.converter.label || this.converter.constructor?.name
+        const name = this.converter.label || this.converter.constructor.name
         return name && name !== 'Function' ? name : undefined
     }
 

--- a/packages/mobx-binder-core/src/model/binder/chain/ConvertingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ConvertingModifier.ts
@@ -19,7 +19,7 @@ export class ConvertingModifier<ValidationResult, ViewType, ModelType> extends A
     }
 
     get name() {
-        const name = this.converter.constructor?.name
+        const name = this.converter.label || this.converter.constructor?.name
         return name && name !== 'Function' ? name : undefined
     }
 

--- a/packages/mobx-binder-core/src/model/binder/chain/ConvertingModifierSpec.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ConvertingModifierSpec.ts
@@ -37,6 +37,23 @@ describe('ConvertingModifier', () => {
         modifier = new ConvertingModifier(upstream, context, converter)
     })
 
+    describe('name', () => {
+        it('should provide a name of the converter', () => {
+            expect(modifier.name).to.equal('SimpleNumberConverter')
+        })
+
+        it('should support a label on the converter', () => {
+            ;(converter as any).label = 'Some converter'
+            expect(modifier.name).to.equal('Some converter')
+        })
+    })
+
+    describe('type', () => {
+        it('should provide a type', () => {
+            expect(modifier.type).to.equal('conversion')
+        })
+    })
+
     describe('data', () => {
         it('should convert valid upstream data', () => {
             expect(modifier.data).to.deep.equal({

--- a/packages/mobx-binder-core/src/model/binder/chain/FieldWrapper.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/FieldWrapper.ts
@@ -33,10 +33,12 @@ export class FieldWrapper<ValidationResult, ValueType> implements Modifier<Valid
         const { type, data, required, validity } = this
         return [
             {
+                name: this.field.name,
                 type,
                 data,
                 required,
                 validity,
+                more: this.field.debugState,
             },
         ]
     }

--- a/packages/mobx-binder-core/src/model/binder/chain/FieldWrapper.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/FieldWrapper.ts
@@ -2,9 +2,14 @@ import { KnownData, Modifier, ValidValueValidationResult } from './Modifier'
 import { Context } from '../Context'
 import { FieldStore } from '../../fields/FieldStore'
 import { Validity } from '../../../validation/Validity'
+import { ModifierState } from './ModifierState'
 
 export class FieldWrapper<ValidationResult, ValueType> implements Modifier<ValidationResult, ValueType, ValueType> {
     constructor(public field: FieldStore<ValueType>, private context: Context<ValidationResult>) {}
+
+    get type() {
+        return `field<${this.field.valueType}>`
+    }
 
     get data(): KnownData<ValueType> {
         return {
@@ -22,6 +27,18 @@ export class FieldWrapper<ValidationResult, ValueType> implements Modifier<Valid
             status: 'validated',
             result: this.context.validResult,
         }
+    }
+
+    public get bindingState(): Array<ModifierState<ValidationResult>> {
+        const { type, data, required, validity } = this
+        return [
+            {
+                type,
+                data,
+                required,
+                validity,
+            },
+        ]
     }
 
     public toView(modelValue: any) {

--- a/packages/mobx-binder-core/src/model/binder/chain/Modifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/Modifier.ts
@@ -31,6 +31,7 @@ export interface InvalidValueValidationResult<ValidationResult> {
 }
 
 export interface Modifier<ValidationResult, ViewType, ModelType> {
+    name?: string
     type: string
     bindingState: Array<ModifierState<ValidationResult>>
     field: FieldStore<unknown>

--- a/packages/mobx-binder-core/src/model/binder/chain/Modifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/Modifier.ts
@@ -1,5 +1,6 @@
 import { FieldStore } from '../../fields/FieldStore'
 import { Validity } from '../../../validation/Validity'
+import { ModifierState } from './ModifierState'
 
 export type Data<ValueType> = KnownData<ValueType> | UnknownData<ValueType>
 
@@ -30,6 +31,8 @@ export interface InvalidValueValidationResult<ValidationResult> {
 }
 
 export interface Modifier<ValidationResult, ViewType, ModelType> {
+    type: string
+    bindingState: Array<ModifierState<ValidationResult>>
     field: FieldStore<unknown>
     data: Data<ModelType>
     validity: Validity<ValidationResult>

--- a/packages/mobx-binder-core/src/model/binder/chain/ModifierState.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ModifierState.ts
@@ -1,0 +1,9 @@
+import { Validity } from '../../../validation/Validity'
+import { Data } from './Modifier'
+
+export interface ModifierState<ValidationResult> {
+    type: string
+    data: Data<unknown>
+    validity: Validity<ValidationResult>
+    required: boolean
+}

--- a/packages/mobx-binder-core/src/model/binder/chain/ModifierState.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ModifierState.ts
@@ -2,8 +2,10 @@ import { Validity } from '../../../validation/Validity'
 import { Data } from './Modifier'
 
 export interface ModifierState<ValidationResult> {
+    name?: string
     type: string
     data: Data<unknown>
     validity: Validity<ValidationResult>
     required: boolean
+    more?: unknown
 }

--- a/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifier.ts
@@ -19,6 +19,11 @@ export class ValidatingModifier<ValidationResult, ValueType> extends AbstractMod
         })
     }
 
+    get type() {
+        const name = this.validator.constructor?.name
+        return name && name !== 'Function' ? `validation:${name}` : 'validation'
+    }
+
     get data(): Data<ValueType> {
         const data = this.view.data
         if (data.pending || this.isDisabled) {

--- a/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifier.ts
@@ -19,9 +19,13 @@ export class ValidatingModifier<ValidationResult, ValueType> extends AbstractMod
         })
     }
 
-    get type() {
+    get name() {
         const name = this.validator.constructor?.name
-        return name && name !== 'Function' ? `validation:${name}` : 'validation'
+        return name && name !== 'Function' ? name : undefined
+    }
+
+    get type() {
+        return 'validation'
     }
 
     get data(): Data<ValueType> {

--- a/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifier.ts
@@ -44,7 +44,7 @@ export class ValidatingModifier<ValidationResult, ValueType> extends AbstractMod
     }
 
     get required() {
-        return isWrapper(this.validator) && this.validator.required ? this.validator.required() : this.view.required
+        return isWrapper(this.validator) ? this.validator.required() : this.view.required
     }
 
     get validity() {
@@ -52,7 +52,7 @@ export class ValidatingModifier<ValidationResult, ValueType> extends AbstractMod
     }
 
     private get isDisabled() {
-        return isWrapper(this.validator) && this.validator.required && !this.validator.required()
+        return isWrapper(this.validator) && !this.validator.required()
     }
 
     public async validateAsync(blurEvent: boolean): Promise<Validity<ValidationResult>> {

--- a/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifier.ts
@@ -5,6 +5,7 @@ import { AbstractModifier } from './AbstractModifier'
 import { Validity } from '../../../validation/Validity'
 import { isWrapper } from '../../../validation/WrappedValidator'
 import { computed, makeObservable, runInAction } from 'mobx'
+import { isLabeled } from '../../../validation/Labels'
 
 export class ValidatingModifier<ValidationResult, ValueType> extends AbstractModifier<ValidationResult, ValueType, ValueType> {
     constructor(
@@ -20,7 +21,7 @@ export class ValidatingModifier<ValidationResult, ValueType> extends AbstractMod
     }
 
     get name() {
-        const name = this.validator.constructor?.name
+        const name = isLabeled(this.validator) ? this.validator.label : this.validator.constructor?.name
         return name && name !== 'Function' ? name : undefined
     }
 

--- a/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifier.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifier.ts
@@ -21,8 +21,7 @@ export class ValidatingModifier<ValidationResult, ValueType> extends AbstractMod
     }
 
     get name() {
-        const name = isLabeled(this.validator) ? this.validator.label : this.validator.constructor?.name
-        return name && name !== 'Function' ? name : undefined
+        return isLabeled(this.validator) ? this.validator.label : this.validator.name
     }
 
     get type() {

--- a/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifierSpec.ts
+++ b/packages/mobx-binder-core/src/model/binder/chain/ValidatingModifierSpec.ts
@@ -1,4 +1,4 @@
-import { TextField } from '../../..'
+import { TextField, withLabel } from '../../..'
 import { ErrorMessage, SimpleContext } from '../SimpleBinder'
 import { expect } from 'chai'
 import { ValidatingModifier } from './ValidatingModifier'
@@ -38,6 +38,28 @@ describe('ValidatingModifier', () => {
         }
         validatorMock = sandbox.stub()
         modifier = new ValidatingModifier<ErrorMessage, string>(upstream, context, validatorMock)
+    })
+
+    describe('name', () => {
+        it('should provide a name of the converter', () => {
+            const myValidator = (value: string) => (!!value ? 'required' : undefined)
+            modifier = new ValidatingModifier<ErrorMessage, string>(upstream, context, myValidator)
+
+            expect(modifier.name).to.equal('myValidator')
+        })
+
+        it('should support a label on the converter', () => {
+            const myValidator = (value: string) => (!!value ? 'required' : undefined)
+            validatorMock = withLabel('some validator', myValidator)
+            modifier = new ValidatingModifier<ErrorMessage, string>(upstream, context, validatorMock)
+            expect(modifier.name).to.equal('some validator')
+        })
+    })
+
+    describe('type', () => {
+        it('should provide a type', () => {
+            expect(modifier.type).to.equal('validation')
+        })
     })
 
     describe('data', () => {

--- a/packages/mobx-binder-core/src/model/fields/FieldStore.ts
+++ b/packages/mobx-binder-core/src/model/fields/FieldStore.ts
@@ -66,6 +66,9 @@ export interface FieldStore<ValueType> {
      */
     required: boolean
 
+    /**
+     * Optionally return an object with field state rendered into the Binding.state for debugging purposes.
+     */
     readonly debugState?: unknown
 
     /**

--- a/packages/mobx-binder-core/src/model/fields/FieldStore.ts
+++ b/packages/mobx-binder-core/src/model/fields/FieldStore.ts
@@ -51,7 +51,7 @@ export interface FieldStore<ValueType> {
 
     /**
      * If `valid === false`, containing the validation message.
-     * This property is replaced by a getter/setter on bind.
+     * This property is bound to .
      */
     errorMessage?: string
 

--- a/packages/mobx-binder-core/src/model/fields/FieldStore.ts
+++ b/packages/mobx-binder-core/src/model/fields/FieldStore.ts
@@ -66,6 +66,8 @@ export interface FieldStore<ValueType> {
      */
     required: boolean
 
+    readonly debugState?: unknown
+
     /**
      * This function must be used to update field values via the frontend.
      *

--- a/packages/mobx-binder-core/src/validation/Labels.ts
+++ b/packages/mobx-binder-core/src/validation/Labels.ts
@@ -1,0 +1,48 @@
+import { Validator } from './Validator'
+
+export interface LabeledValidator<ValidationResult, T> extends Validator<ValidationResult, T> {
+    label: string
+}
+
+export function isLabeled<ValidationResult, T>(validator: Validator<ValidationResult, T>): validator is LabeledValidator<ValidationResult, T> {
+    return (validator as object).hasOwnProperty('label')
+}
+
+const createArgumentString = (data: Record<string, unknown>) => {
+    if (!data) {
+        return ''
+    }
+    const parts = Object.keys(data)
+        .reduce((parts: string[], key: string) => {
+            const value = data[key]
+            if (value !== undefined) {
+                parts.push(`${key}=${JSON.stringify(value)}`)
+            }
+            return parts
+        }, [])
+        .join(',')
+    return parts.length ? `(${parts})` : ''
+}
+
+export const createLabel = (name: string, args: Record<string, unknown>) => {
+    return `${name}${createArgumentString(args)}`
+}
+
+export function withLabel<ValidationResult, T>(label: string, validator: Validator<ValidationResult, T>): LabeledValidator<ValidationResult, T>
+export function withLabel<ValidationResult, T>(
+    label: string,
+    params: Record<string, unknown>,
+    validator: Validator<ValidationResult, T>,
+): LabeledValidator<ValidationResult, T>
+export function withLabel<ValidationResult, T>(
+    label: string,
+    second: Record<string, unknown> | Validator<ValidationResult, T>,
+    validator?: Validator<ValidationResult, T>,
+): LabeledValidator<ValidationResult, T> {
+    if (validator && typeof second === 'object') {
+        return Object.assign((value: T) => validator(value), { label: createLabel(label, second) })
+    } else if (typeof second === 'function') {
+        return Object.assign((value: T) => second(value), { label })
+    }
+    throw new Error('Illegal arguments passed to "withLabel"')
+}

--- a/packages/mobx-binder-core/src/validation/Labels.ts
+++ b/packages/mobx-binder-core/src/validation/Labels.ts
@@ -9,9 +9,6 @@ export function isLabeled<ValidationResult, T>(validator: Validator<ValidationRe
 }
 
 const createArgumentString = (data: Record<string, unknown>) => {
-    if (!data) {
-        return ''
-    }
     const parts = Object.keys(data)
         .reduce((parts: string[], key: string) => {
             const value = data[key]
@@ -40,9 +37,9 @@ export function withLabel<ValidationResult, T>(
     validator?: Validator<ValidationResult, T>,
 ): LabeledValidator<ValidationResult, T> {
     if (validator && typeof second === 'object') {
-        return Object.assign((value: T) => validator(value), { label: createLabel(label, second) })
+        return Object.assign((value: T) => validator(value), { ...validator, label: createLabel(label, second) })
     } else if (typeof second === 'function') {
-        return Object.assign((value: T) => second(value), { label })
+        return Object.assign((value: T) => second(value), { ...second, label })
     }
     throw new Error('Illegal arguments passed to "withLabel"')
 }

--- a/packages/mobx-binder-core/src/validation/LabelsSpec.ts
+++ b/packages/mobx-binder-core/src/validation/LabelsSpec.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { isLabeled, withLabel } from './Labels'
+
+const validator = sinon
+    .stub()
+    .withArgs('test')
+    .returns('result')
+
+describe('LabeledValidator', () => {
+    it('should still validate as before', () => {
+        const wrapper = withLabel('theLabel', validator)
+
+        expect(wrapper('test')).to.equal('result')
+    })
+
+    it('should return false when unlabeled', () => {
+        expect(isLabeled(validator)).to.be.false
+    })
+
+    it('should not alter a validator by itself by labeling it', () => {
+        withLabel('theLabel', validator)
+        expect(isLabeled(validator)).to.be.false
+    })
+
+    it('should provide a property with the label', () => {
+        const wrapper = withLabel('theLabel', validator)
+        expect(isLabeled(wrapper) && wrapper.label).to.equal('theLabel')
+    })
+
+    it('should support async validations', () => {
+        const wrapper = withLabel('async', async value => (!value ? 'required' : undefined))
+        expect(wrapper('')).to.eventually.equal('required')
+        expect(isLabeled(wrapper) && wrapper.label).to.equal('async')
+    })
+
+    describe('labels with arguments', () => {
+        it('should support adding arguments to the label', () => {
+            const wrapper = withLabel('theLabel', { minAge: 12 }, validator)
+
+            expect(wrapper('test')).to.equal('result')
+            expect(isLabeled(wrapper) && wrapper.label).to.equal('theLabel(minAge=12)')
+        })
+
+        it('should not add undefined arguments to the label', () => {
+            const wrapper = withLabel('theLabel', { minAge: 12, maxAge: undefined }, validator)
+
+            expect(wrapper('test')).to.equal('result')
+            expect(isLabeled(wrapper) && wrapper.label).to.equal('theLabel(minAge=12)')
+        })
+    })
+})

--- a/packages/mobx-binder-core/src/validation/LabelsSpec.ts
+++ b/packages/mobx-binder-core/src/validation/LabelsSpec.ts
@@ -34,6 +34,12 @@ describe('LabeledValidator', () => {
         expect(isLabeled(wrapper) && wrapper.label).to.equal('async')
     })
 
+    it('should preserve other attributes of the function', () => {
+        const validator: any = (value: string) => (!value ? 'required' : undefined)
+        validator.someProp = 'test'
+        expect((withLabel('someLabel', validator) as any).someProp).to.equal('test')
+    })
+
     describe('labels with arguments', () => {
         it('should support adding arguments to the label', () => {
             const wrapper = withLabel('theLabel', { minAge: 12 }, validator)

--- a/packages/mobx-binder-core/src/validation/WrappedValidator.ts
+++ b/packages/mobx-binder-core/src/validation/WrappedValidator.ts
@@ -1,13 +1,20 @@
 import { Validator } from './Validator'
+import { withLabel } from './Labels'
 
 export interface WrappedValidator<ValidationResult, T> extends Validator<ValidationResult, T> {
-    required?: () => boolean
+    required: () => boolean
 }
 
 export function isWrapper<ValidationResult, T>(validator: Validator<ValidationResult, T>): validator is WrappedValidator<ValidationResult, T> {
     return (validator as object).hasOwnProperty('required')
 }
 
-export function wrapRequiredValidator<ValidationResult, T>(validator: Validator<ValidationResult, T>, required: () => boolean = () => true) {
-    return Object.assign((value: T): ValidationResult => validator(value), { required })
+export function wrapRequiredValidator<ValidationResult, T>(
+    validator: Validator<ValidationResult, T>,
+    required: () => boolean = () => true,
+): WrappedValidator<ValidationResult, T> {
+    return Object.assign(
+        withLabel('required', { value: required() }, (value: T): ValidationResult => validator(value)),
+        { required },
+    )
 }

--- a/packages/mobx-binder-core/src/validation/WrappedValidatorSpec.ts
+++ b/packages/mobx-binder-core/src/validation/WrappedValidatorSpec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { isWrapper, wrapRequiredValidator } from './WrappedValidator'
 import sinon from 'sinon'
+import { isLabeled } from './Labels'
 
 const validator = sinon
     .stub()
@@ -19,5 +20,10 @@ describe('WrappedValidator', () => {
 
         const wrapper2 = wrapRequiredValidator(validator, () => false)
         expect(isWrapper(wrapper2) && wrapper2.required()).to.be.false
+    })
+
+    it('should provide a label', () => {
+        const wrapper = wrapRequiredValidator(validator, () => true)
+        expect(isLabeled(wrapper) && wrapper.label).to.equal('required(value=true)')
     })
 })

--- a/packages/mobx-binder-dayjs/.eslintrc.js
+++ b/packages/mobx-binder-dayjs/.eslintrc.js
@@ -2,4 +2,7 @@ module.exports =  {
     extends:  [
         '../mobx-binder-utils/.eslintrc.js',
     ],
+    parserOptions: {
+        project: 'tsconfig.json'
+    },
 };

--- a/packages/mobx-binder-dayjs/src/conversion/DayjsConverter.ts
+++ b/packages/mobx-binder-dayjs/src/conversion/DayjsConverter.ts
@@ -1,13 +1,17 @@
 import dayjs, { Dayjs } from 'dayjs'
-import { BinderValidationResult, Converter, ValidationError } from 'mobx-binder'
+import { BinderValidationResult, Converter, ValidationError, createLabel } from 'mobx-binder'
 
 export class DayjsConverter implements Converter<BinderValidationResult, string | undefined, Dayjs | undefined> {
+    readonly label: string
+
     constructor(
         private formats: string | string[],
         private locale: string | undefined = undefined,
         private strict = false,
         private errorMessage = 'conversions.error.dayjs',
-    ) {}
+    ) {
+        this.label = createLabel('MomentConverter', { formats: JSON.stringify(formats), locale, strict })
+    }
 
     private get primaryFormat() {
         const formats = this.formats

--- a/packages/mobx-binder-dayjs/src/validation/DayjsValidators.ts
+++ b/packages/mobx-binder-dayjs/src/validation/DayjsValidators.ts
@@ -1,31 +1,39 @@
-import { BinderValidationResult, BinderValidator } from 'mobx-binder'
+import { BinderValidationResult, BinderValidator, withLabel } from 'mobx-binder'
 import dayjs, { Dayjs, isDayjs } from 'dayjs'
 
 export class DayjsValidators {
     public static dayInFuture(messageKey = 'validations.dayInFuture'): BinderValidator<Dayjs> {
-        return value => DayjsValidators.validate(isDayjs(value) && value.diff(DayjsValidators.today(), 'day') <= 0, messageKey, { value })
+        return withLabel('dayInFuture', value =>
+            DayjsValidators.validate(isDayjs(value) && value.diff(DayjsValidators.today(), 'day') <= 0, messageKey, { value }),
+        )
     }
 
     public static todayOrInFuture(messageKey = 'validations.todayOrInFuture'): BinderValidator<Dayjs> {
-        return value => DayjsValidators.validate(isDayjs(value) && value.diff(DayjsValidators.today(), 'day') < 0, messageKey, { value })
+        return withLabel('todayOrInFuture', value =>
+            DayjsValidators.validate(isDayjs(value) && value.diff(DayjsValidators.today(), 'day') < 0, messageKey, { value }),
+        )
     }
 
     public static dayInPast(messageKey = 'validations.dayInPast'): BinderValidator<Dayjs> {
-        return value => DayjsValidators.validate(isDayjs(value) && value.diff(DayjsValidators.today(), 'day') >= 0, messageKey, { value })
+        return withLabel('dayInPast', value =>
+            DayjsValidators.validate(isDayjs(value) && value.diff(DayjsValidators.today(), 'day') >= 0, messageKey, { value }),
+        )
     }
 
     public static age(minAge?: number, maxAge?: number, messageKey = 'validations.age'): BinderValidator<Dayjs> {
-        return value => {
+        return withLabel('age', { minAge, maxAge }, value => {
             if (isDayjs(value)) {
                 const theAge = DayjsValidators.today().diff(value, 'year')
                 return DayjsValidators.validate((!!minAge && theAge < minAge) || (!!maxAge && theAge > maxAge), messageKey, { minAge, maxAge, value })
             }
             return {}
-        }
+        })
     }
 
     public static todayOrInPast(messageKey = 'validations.todayOrInPast'): BinderValidator<Dayjs> {
-        return value => DayjsValidators.validate(isDayjs(value) && value.diff(DayjsValidators.today(), 'day') > 0, messageKey, { value })
+        return withLabel('todayOrInPast', value =>
+            DayjsValidators.validate(isDayjs(value) && value.diff(DayjsValidators.today(), 'day') > 0, messageKey, { value }),
+        )
     }
 
     private static validate(errorCondition: boolean, message: string, args?: any): BinderValidationResult {

--- a/packages/mobx-binder-dayjs/src/validation/DayjsValidatorsSpec.ts
+++ b/packages/mobx-binder-dayjs/src/validation/DayjsValidatorsSpec.ts
@@ -5,6 +5,7 @@ import { DayjsValidators } from './DayjsValidators'
 import data_driven = require('data-driven')
 import sinon = require('sinon')
 import dayjs = require('dayjs')
+import { isLabeled } from 'mobx-binder'
 
 describe('DayjsValidators', () => {
     const sandbox = sinon.createSandbox()
@@ -45,6 +46,12 @@ describe('DayjsValidators', () => {
                 const rule = (DayjsValidators as any)[ctx.method](...ctx.args)
 
                 expect(rule(ctx.value)).to.deep.equal({})
+            })
+
+            it('should be labeled validator {method}', (ctx: any) => {
+                const rule = (DayjsValidators as any)[ctx.method](...ctx.args)
+
+                expect(isLabeled(rule) && rule.label.substring(0, ctx.method.length)).to.equal(ctx.method)
             })
         },
     )

--- a/packages/mobx-binder-dayjs/src/validation/DayjsValidatorsSpec.ts
+++ b/packages/mobx-binder-dayjs/src/validation/DayjsValidatorsSpec.ts
@@ -77,7 +77,7 @@ describe('DayjsValidators', () => {
                     messageKey: `validations.${ctx.method}`,
                     args: {
                         value: ctx.value,
-                        ...(ctx.messageArgs || {}),
+                        ...(ctx.messageArgs ?? {}),
                     },
                 })
             })
@@ -89,7 +89,7 @@ describe('DayjsValidators', () => {
                     messageKey: `custom.key`,
                     args: {
                         value: ctx.value,
-                        ...(ctx.messageArgs || {}),
+                        ...(ctx.messageArgs ?? {}),
                     },
                 })
             })

--- a/packages/mobx-binder-moment/.eslintrc.js
+++ b/packages/mobx-binder-moment/.eslintrc.js
@@ -2,4 +2,7 @@ module.exports =  {
     extends:  [
         '../mobx-binder-utils/.eslintrc.js',
     ],
+    parserOptions: {
+        project: 'tsconfig.json'
+    },
 };

--- a/packages/mobx-binder-moment/src/conversion/MomentConverter.ts
+++ b/packages/mobx-binder-moment/src/conversion/MomentConverter.ts
@@ -1,8 +1,12 @@
 import moment from 'moment'
-import { BinderValidationResult, Converter, ValidationError } from 'mobx-binder'
+import { BinderValidationResult, Converter, ValidationError, createLabel } from 'mobx-binder'
 
 export class MomentConverter implements Converter<BinderValidationResult, string | undefined, moment.Moment | undefined> {
-    constructor(private format: string, private errorMessage = 'conversions.error.moment') {}
+    readonly label: string
+
+    constructor(private format: string, private errorMessage = 'conversions.error.moment') {
+        this.label = createLabel('MomentConverter', { format })
+    }
 
     public convertToModel(value?: string): moment.Moment | undefined {
         if (!!value) {

--- a/packages/mobx-binder-moment/src/validation/MomentValidators.ts
+++ b/packages/mobx-binder-moment/src/validation/MomentValidators.ts
@@ -1,31 +1,39 @@
 import moment from 'moment'
-import { BinderValidationResult, BinderValidator } from 'mobx-binder'
+import { BinderValidationResult, BinderValidator, withLabel } from 'mobx-binder'
 
 export class MomentValidators {
     public static dayInFuture(messageKey = 'validations.dayInFuture'): BinderValidator<moment.Moment> {
-        return value => MomentValidators.validate(moment.isMoment(value) && value.diff(MomentValidators.today(), 'days') <= 0, messageKey, { value })
+        return withLabel('dayInFuture', value =>
+            MomentValidators.validate(moment.isMoment(value) && value.diff(MomentValidators.today(), 'days') <= 0, messageKey, { value }),
+        )
     }
 
     public static todayOrInFuture(messageKey = 'validations.todayOrInFuture'): BinderValidator<moment.Moment> {
-        return value => MomentValidators.validate(moment.isMoment(value) && value.diff(MomentValidators.today(), 'days') < 0, messageKey, { value })
+        return withLabel('todayOrInFuture', value =>
+            MomentValidators.validate(moment.isMoment(value) && value.diff(MomentValidators.today(), 'days') < 0, messageKey, { value }),
+        )
     }
 
     public static dayInPast(messageKey = 'validations.dayInPast'): BinderValidator<moment.Moment> {
-        return value => MomentValidators.validate(moment.isMoment(value) && value.diff(MomentValidators.today(), 'days') >= 0, messageKey, { value })
+        return withLabel('dayInPast', value =>
+            MomentValidators.validate(moment.isMoment(value) && value.diff(MomentValidators.today(), 'days') >= 0, messageKey, { value }),
+        )
     }
 
     public static age(minAge?: number, maxAge?: number, messageKey = 'validations.age'): BinderValidator<moment.Moment> {
-        return value => {
+        return withLabel('age', { minAge, maxAge }, value => {
             if (moment.isMoment(value)) {
                 const theAge = MomentValidators.today().diff(value, 'years')
                 return MomentValidators.validate((!!minAge && theAge < minAge) || (!!maxAge && theAge > maxAge), messageKey, { minAge, maxAge, value })
             }
             return {}
-        }
+        })
     }
 
     public static todayOrInPast(messageKey = 'validations.todayOrInPast'): BinderValidator<moment.Moment> {
-        return value => MomentValidators.validate(moment.isMoment(value) && value.diff(MomentValidators.today(), 'days') > 0, messageKey, { value })
+        return withLabel('todayOrInPast', value =>
+            MomentValidators.validate(moment.isMoment(value) && value.diff(MomentValidators.today(), 'days') > 0, messageKey, { value }),
+        )
     }
 
     private static validate(errorCondition: boolean, message: string, args?: any): BinderValidationResult {

--- a/packages/mobx-binder-moment/src/validation/MomentValidatorsSpec.ts
+++ b/packages/mobx-binder-moment/src/validation/MomentValidatorsSpec.ts
@@ -5,6 +5,7 @@ import moment from 'moment'
 // eslint-disable-next-line @typescript-eslint/camelcase
 import data_driven = require('data-driven')
 import sinon = require('sinon')
+import { isLabeled } from 'mobx-binder'
 
 describe('MomentValidators', () => {
     const sandbox = sinon.createSandbox()
@@ -45,6 +46,12 @@ describe('MomentValidators', () => {
                 const rule = (MomentValidators as any)[ctx.method](...ctx.args)
 
                 expect(rule(ctx.value)).to.deep.equal({})
+            })
+
+            it('should be labeled validator {method}', (ctx: any) => {
+                const rule = (MomentValidators as any)[ctx.method](...ctx.args)
+
+                expect(isLabeled(rule) && rule.label.substring(0, ctx.method.length)).to.equal(ctx.method)
             })
         },
     )

--- a/packages/mobx-binder-moment/src/validation/MomentValidatorsSpec.ts
+++ b/packages/mobx-binder-moment/src/validation/MomentValidatorsSpec.ts
@@ -77,7 +77,7 @@ describe('MomentValidators', () => {
                     messageKey: `validations.${ctx.method}`,
                     args: {
                         value: ctx.value,
-                        ...(ctx.messageArgs || {}),
+                        ...(ctx.messageArgs ?? {}),
                     },
                 })
             })
@@ -89,7 +89,7 @@ describe('MomentValidators', () => {
                     messageKey: `custom.key`,
                     args: {
                         value: ctx.value,
-                        ...(ctx.messageArgs || {}),
+                        ...(ctx.messageArgs ?? {}),
                     },
                 })
             })

--- a/packages/mobx-binder-utils/.eslintrc.js
+++ b/packages/mobx-binder-utils/.eslintrc.js
@@ -18,10 +18,22 @@ module.exports = {
         // e.g. "@typescript-eslint/explicit-function-return-type": "off",
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-unnecessary-condition': 'error',
         'no-restricted-imports': ["error", {
             patterns: ['mobx-binder*/', '.*/mobx-binder']
-        }]
+        }],
+        'no-unused-expressions': 'off',
+        'object-shorthand': ['error', 'always'],
+
     },
+    "overrides": [
+        {
+            "files": ['*Spec.ts', 'src/test/**'],
+            "rules": {
+                '@typescript-eslint/no-unused-expressions': "off",
+            }
+        }
+    ],
     settings: {
         react: {
             version: 'detect',  // Tells eslint-plugin-react to automatically detect the version of React to use

--- a/packages/mobx-binder/.eslintrc.js
+++ b/packages/mobx-binder/.eslintrc.js
@@ -2,4 +2,7 @@ module.exports =  {
     extends:  [
         '../mobx-binder-utils/.eslintrc.js',
     ],
+    parserOptions: {
+        project: 'tsconfig.json'
+    },
 };

--- a/packages/mobx-binder/src/model/DefaultBinder.ts
+++ b/packages/mobx-binder/src/model/DefaultBinder.ts
@@ -13,7 +13,7 @@ export class DefaultContext implements Context<BinderValidationResult> {
     public readonly validResult: ValidBinderValidationResult = {}
 
     constructor(private options: DefaultContextOptions) {
-        this.requiredValidator = options.requiredValidator || StringValidators.required
+        this.requiredValidator = options.requiredValidator ?? StringValidators.required
     }
 
     public translate(result: BinderValidationResult) {

--- a/packages/mobx-binder/src/test/BinderSamples.ts
+++ b/packages/mobx-binder/src/test/BinderSamples.ts
@@ -1,8 +1,7 @@
 export default class BinderSamples {
-    public static t(message: string, args?: { [s: string]: any }): string {
-        const theArgs = args || {}
-        const argsString = Object.keys(theArgs)
-            .map(key => `${key}=${theArgs[key]}`)
+    public static t(message: string, args: { [s: string]: any } = {}): string {
+        const argsString = Object.keys(args)
+            .map(key => `${key}=${args[key]}`)
             .join(',')
 
         return `${message}(${argsString})`

--- a/packages/mobx-binder/src/validation/EmailValidator.ts
+++ b/packages/mobx-binder/src/validation/EmailValidator.ts
@@ -1,8 +1,9 @@
 import emailValidator from 'email-validator'
 import { BinderValidator } from './Validation'
+import { withLabel } from 'mobx-binder-core'
 
 export class EmailValidator {
     public static validate(messageKey = 'validations.email'): BinderValidator<string> {
-        return value => (!!value && !emailValidator.validate(value) ? { messageKey, args: { value } } : {})
+        return withLabel('email', value => (!!value && !emailValidator.validate(value) ? { messageKey, args: { value } } : {}))
     }
 }

--- a/packages/mobx-binder/src/validation/StringValidators.ts
+++ b/packages/mobx-binder/src/validation/StringValidators.ts
@@ -1,45 +1,51 @@
 import { BinderValidationResult, BinderValidator } from './Validation'
+import { withLabel } from 'mobx-binder-core'
 
 export class StringValidators {
     public static matchLength(match: number, messageKey = 'validations.matchLength'): BinderValidator<string> {
-        return value => StringValidators.validate(!!value && value.length !== match, messageKey, { value, match })
+        return withLabel('matchLength', { match }, value => StringValidators.validate(!!value && value.length !== match, messageKey, { value, match }))
     }
 
     public static minLength(min: number, messageKey = 'validations.minLength'): BinderValidator<string> {
-        return value => StringValidators.validate(!!value && value.length < min, messageKey, { value, min })
+        return withLabel('minLength', { min }, value => StringValidators.validate(!!value && value.length < min, messageKey, { value, min }))
     }
 
     public static maxLength(max: number, messageKey = 'validations.maxLength'): BinderValidator<string> {
-        return value => StringValidators.validate(!!value && value.length > max, messageKey, { value, max })
+        return withLabel('maxLength', { max }, value => StringValidators.validate(!!value && value.length > max, messageKey, { value, max }))
     }
 
     public static lengths(min: number, max: number, messageKey = 'validations.lengths'): BinderValidator<string> {
-        return value => StringValidators.validate(!!value && (value.length < min || value.length > max), messageKey, { value, min, max })
+        return withLabel('lengths', { min, max }, value =>
+            StringValidators.validate(!!value && (value.length < min || value.length > max), messageKey, { value, min, max }),
+        )
     }
 
     public static required<T>(messageKey = 'validations.required'): BinderValidator<T> {
-        return value => StringValidators.validate(value === undefined || value === null || (typeof value === 'string' && value === ''), messageKey)
+        return withLabel('required', { value: true }, value =>
+            StringValidators.validate(value === undefined || value === null || (typeof value === 'string' && value === ''), messageKey),
+        )
     }
 
     public static equals<T>(expectedValue: string | boolean, messageKey = 'validations.equals'): BinderValidator<T> {
-        return value =>
+        return withLabel('equals', { expectedValue }, value =>
             StringValidators.validate(
                 (typeof value === 'string' && value !== expectedValue) || (typeof value === 'boolean' && value !== expectedValue),
                 messageKey,
                 { value },
-            )
+            ),
+        )
     }
 
     public static regexp(regexp: RegExp, messageKey = 'validations.regexp'): BinderValidator<string> {
-        return value => {
+        return withLabel('regexp', { regexp }, value => {
             regexp.lastIndex = 0
             const mismatch = !!value && !regexp.test(value)
             return StringValidators.validate(mismatch, messageKey, { value, regexp: regexp.toString() })
-        }
+        })
     }
 
     public static noWhitespaces(messageKey = 'validations.noWhitespaces'): BinderValidator<string> {
-        return value => StringValidators.validate(!!value && /\s/.test(value), messageKey, { value })
+        return withLabel('noWhitespaces', value => StringValidators.validate(!!value && /\s/.test(value), messageKey, { value }))
     }
 
     private static validate(errorCondition: boolean, message: string, args?: any): BinderValidationResult {

--- a/packages/mobx-binder/src/validation/StringValidatorsSpec.ts
+++ b/packages/mobx-binder/src/validation/StringValidatorsSpec.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai'
 import data_driven = require('data-driven')
 
 import { StringValidators } from './StringValidators'
+import { isLabeled } from 'mobx-binder-core'
 
 describe('Validators', () => {
     data_driven(
@@ -26,6 +27,12 @@ describe('Validators', () => {
                 const rule = (StringValidators as any)[ctx.method](...ctx.args)
 
                 expect(rule(ctx.value)).to.deep.equal({})
+            })
+
+            it('should be labeled validator {method}', (ctx: any) => {
+                const rule = (StringValidators as any)[ctx.method](...ctx.args)
+
+                expect(isLabeled(rule) && rule.label.substring(0, ctx.method.length)).to.equal(ctx.method)
             })
         },
     )

--- a/packages/sample/.eslintrc.js
+++ b/packages/sample/.eslintrc.js
@@ -2,4 +2,7 @@ module.exports =  {
     extends:  [
         '../mobx-binder-utils/.eslintrc.js',
     ],
+    parserOptions: {
+        project: 'tsconfig.json'
+    },
 };

--- a/packages/sample/src/app/forms/FormField.tsx
+++ b/packages/sample/src/app/forms/FormField.tsx
@@ -16,7 +16,7 @@ export const FormField = observer(({ field }: FormFieldProps) => {
     const showValidationResults = !field.validating && field.showValidationResults
     const valid = showValidationResults && field.valid === true
     const invalid = showValidationResults && field.valid === false
-    const errorMessage = showValidationResults ? field.errorMessage || null : null
+    const errorMessage = showValidationResults && field.errorMessage ? field.errorMessage : null
 
     const handleBlur = () => {
         field.handleBlur()


### PR DESCRIPTION
Return a list of state information for each modification (validation, conversion) of a particular binding for debugging purposes